### PR TITLE
Added support for assembly names containing dots to PackResolver.

### DIFF
--- a/src/Resolvers/PackResolver.cs
+++ b/src/Resolvers/PackResolver.cs
@@ -10,7 +10,7 @@ namespace ImagePreview.Resolvers
 {
     internal class PackResolver : IImageResolver
     {
-        private static readonly string _pattern = $@"(pack://application:[^/]+)?/[\w]+;component/(?<image>[^""]+\.(?<ext>{BitmapImageCheck.Instance.AllSupportedExtensionsString}))\b";
+        private static readonly string _pattern = $@"(pack://application:[^/]+)?/[\w.]+;component/(?<image>[^""]+\.(?<ext>{BitmapImageCheck.Instance.AllSupportedExtensionsString}))\b";
         private static readonly Regex _regex = new(_pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public string DisplayName => "Pack URI";

--- a/test/PackResolverTest.cs
+++ b/test/PackResolverTest.cs
@@ -19,6 +19,8 @@ namespace ImagePreview.Test
 
         [DataTestMethod]
         [DataRow("/MyAssembly;component/foo.png", "foo.png")]
+        [DataRow("/MyAssembly.Second;component/foo.png", "foo.png")]
+        [DataRow("/MyAssembly.Second.Third;component/foo.png", "foo.png")]
         [DataRow("/MyAssembly;component/bar/foo.png", "bar/foo.png")]
         [DataRow("\"/MyAssembly;component/bar/foo.png\"", "bar/foo.png")]
         public void Short(string path, string match)
@@ -31,6 +33,8 @@ namespace ImagePreview.Test
 
         [DataTestMethod]
         [DataRow("pack://application:,,,/MyAssembly;component/foo.png", @"foo.png")]
+        [DataRow("pack://application:,,,/MyAssembly.Second;component/foo.png", @"foo.png")]
+        [DataRow("pack://application:,,,/MyAssembly.Second.Third;component/foo.png", @"foo.png")]
         [DataRow("pack://application:,,,/MyAssembly;component/bar/foo.png", @"bar/foo.png")]
         [DataRow("\"pack://application:,,,/MyAssembly;component/bar/foo.png\"", @"bar/foo.png")]
         public void Long(string path, string match)


### PR DESCRIPTION
I tried the extension and noticed that none of my images were showing. Turns out that it was only accepting assembly names consisting of a single word and all my assemblies are named "CompanyName.ProductName.ProjectName".

I added a dot to the regex and added a few test cases. It also worked when I debugged the extension.

There are probably more allowable characters but I couldn't find the assembly naming conventions and the dot is the most popular separator.